### PR TITLE
Update trigger to accommodate new business needs

### DIFF
--- a/OpportunityTrigger.tgr
+++ b/OpportunityTrigger.tgr
@@ -60,9 +60,11 @@ trigger OpportunityTrigger on Opportunity (after insert, after update) {
     //This updates the account records by copying data from an Opportunity that has been
     // invoiced AND is the most recently modifyied opportunity on an account.
     public void updateAcctExp(){
-        List<Account> accLst = [SELECT Id, 
+        List<Account> accLst = [SELECT Id,
+                                Annual_Membership_Start_Date__c,
                                 Most_Recent_Expiration__c,
-                                Name
+                                Name,
+                                Membership_Type__c
                                 FROM Account WHERE Id IN :accs];
         //I am not sure why it is neccessary to map this objects into a id/Opp hash but the code works as is.
         Map<Id,Opportunity> oppMap = new Map<Id,Opportunity>();
@@ -93,20 +95,29 @@ trigger OpportunityTrigger on Opportunity (after insert, after update) {
         List<Account> updateAcct = new List<Account>();
         for(Account a : accLst){
             if(oppMap.containsKey(a.Id)){
-                Opportunity opp = oppMap.get(a.Id);
-                //system.debug('Account Name that will have values updated ='+ a.Name);
-                //system.debug('Source Opportunity ='+ opp.Name);
-                //Copy customer data that is needed regardless of opportunity type
-                a.Annual_Membership_Start_Date__c = opp.Annual_Membership_Start_Date__c;
-                a.Most_Recent_Expiration__c = opp.Membership_Expiration_Date__c;
-                a.Membership_Term__c = opp.Membership_Term__c;
-                a.Primary_Membership_Contact__c = opp.Primary_Contact__c;
+                Opportunity opp = oppMap.get(a.Id);         
                 
                 //Copy or change PowerSuite subscription specific data 
                 if(opp.RecordType.Name=='Software Subscription'){
                     system.debug('Copying data for PowerSuite opp');
                     a.PowerSuite_Subscription_Amount__c = opp.Amount;
                     a.PowerSuite_Max_Allowed_Users__c = opp.Number_of_PowerSuite_Users__c;
+                    
+                    //If clause is here to ensure that PowerSuite values don't overwrite membership values
+                    //If the customer is already a member            
+                    if(a.Membership_Type__c == 'PowerSuite Paid Subscriber' 
+                       || a.Membership_Type__c == 'Former Member'
+                       || a.Membership_Type__c == 'Non-Member'
+                       || a.Membership_Type__c == null){
+                           
+                            a.Primary_Membership_Contact__c = opp.Primary_Contact__c;
+                            a.Membership_Type__c = 'PowerSuite Paid Subscriber';
+                            a.Annual_Membership_Start_Date__c = opp.Annual_Membership_Start_Date__c;
+                            a.Most_Recent_Expiration__c = opp.Membership_Expiration_Date__c;
+                            a.Membership_Term__c = opp.Membership_Term__c;
+                            system.debug('In special PowerSuite opp if statement='+ a.Annual_Membership_Start_Date__c);
+                    }
+                    
                 }
                 //Otherwise assume it is membership related data that needs to be copied
                 else{
@@ -116,13 +127,15 @@ trigger OpportunityTrigger on Opportunity (after insert, after update) {
                     a.Membership_Type__c = opp.Membership_Type__c;
                     //system.debug(opp.Allowed_Working_Groups_2__c);
                     a.Allowed_Working_Groups__c = opp.Allowed_Working_Groups_2__c;
+                    a.Annual_Membership_Start_Date__c = opp.Annual_Membership_Start_Date__c;
+                    //system.debug('Account start date after copying Membership data='+ a.Annual_Membership_Start_Date__c);
+                	a.Most_Recent_Expiration__c = opp.Membership_Expiration_Date__c;
+                	a.Membership_Term__c = opp.Membership_Term__c;
                 }
-
-                updateAcct.add(a);
-               
+               updateAcct.add(a);
+               update updateAcct;
             }
         }
-        update updateAcct;
         system.debug('Ran Erics Opp Trigger');
     }
 }

--- a/OpportunityTrigger.tgr
+++ b/OpportunityTrigger.tgr
@@ -57,40 +57,69 @@ trigger OpportunityTrigger on Opportunity (after insert, after update) {
         //update updateOpps;
     }
     
-    //This code updates the account records by copying data from an Opportunity that has been invoiced and has a different "Expiration Date" than what is on the account.
+    //This updates the account records by copying data from an Opportunity that has been
+    // invoiced AND is the most recently modifyied opportunity on an account.
     public void updateAcctExp(){
-        List<Account> accLst = [SELECT Id, Most_Recent_Expiration__c FROM Account WHERE Id IN :accs];
+        List<Account> accLst = [SELECT Id, 
+                                Most_Recent_Expiration__c,
+                                Name
+                                FROM Account WHERE Id IN :accs];
+        //I am not sure why it is neccessary to map this objects into a id/Opp hash but the code works as is.
         Map<Id,Opportunity> oppMap = new Map<Id,Opportunity>();
-        for(Opportunity o : [SELECT Id, AccountId, Membership_Expiration_Date__c, StageName, Amount,Membership_Term__c,Allowed_Working_Groups_2__c,Primary_Contact__c,RecordType.Name,Number_of_PowerSuite_Users__c,Membership_Type__c FROM Opportunity 
+        for(Opportunity o : [SELECT Id, 
+                             AccountId,
+                             Annual_Membership_Start_Date__c,
+                             Membership_Expiration_Date__c, 
+                             StageName, 
+                             Amount,
+                             Membership_Term__c,
+                             Allowed_Working_Groups_2__c,
+                             Primary_Contact__c,
+                             RecordType.Name,
+                             Number_of_PowerSuite_Users__c,
+                             Membership_Type__c,
+                             Name
+                             FROM Opportunity 
                              WHERE AccountId IN :accs AND (RecordType.Name = 'Corporate Relations' OR RecordType.Name = 'Affiliate'OR RecordType.Name='Software Subscription') AND StageName = 'Invoiced'
-                             ORDER BY CreatedDate DESC]){
+                             ORDER BY LastModifiedDate DESC]){
+            //This is a trick to get only the first value of on the array stored. I didin't write this code but it seems to work
+            //but it feels like a really weird approach.
             if(oppMap.get(o.AccountId) == null){
-                oppMap.put(o.AccountId, o);
+                oppMap.put(o.AccountId, o);  
             }
         }
         
-        //system.debug(oppMap);
         
         List<Account> updateAcct = new List<Account>();
         for(Account a : accLst){
             if(oppMap.containsKey(a.Id)){
                 Opportunity opp = oppMap.get(a.Id);
-                if( a.Most_Recent_Expiration__c != opp.Membership_Expiration_Date__c){
-                    a.Most_Recent_Expiration__c = opp.Membership_Expiration_Date__c;
-                    if(opp.RecordType.Name=='Software Subscription'){
-                        a.PowerSuite_Subscription_Amount__c = opp.Amount;
-                        a.PowerSuite_Max_Allowed_Users__c = opp.Number_of_PowerSuite_Users__c;
-                        }
-                        else{
-                        a.Membership_Amount__c = opp.Amount;
-                        a.Membership_Type__c = opp.Membership_Type__c;
-                        }
+                //system.debug('Account Name that will have values updated ='+ a.Name);
+                //system.debug('Source Opportunity ='+ opp.Name);
+                //Copy customer data that is needed regardless of opportunity type
+                a.Annual_Membership_Start_Date__c = opp.Annual_Membership_Start_Date__c;
+                a.Most_Recent_Expiration__c = opp.Membership_Expiration_Date__c;
+                a.Membership_Term__c = opp.Membership_Term__c;
+                a.Primary_Membership_Contact__c = opp.Primary_Contact__c;
+                
+                //Copy or change PowerSuite subscription specific data 
+                if(opp.RecordType.Name=='Software Subscription'){
+                    system.debug('Copying data for PowerSuite opp');
+                    a.PowerSuite_Subscription_Amount__c = opp.Amount;
+                    a.PowerSuite_Max_Allowed_Users__c = opp.Number_of_PowerSuite_Users__c;
+                }
+                //Otherwise assume it is membership related data that needs to be copied
+                else{
+                    system.debug('Copying data for membership opp');
+                    a.Primary_Membership_Contact__c = opp.Primary_Contact__c;
+                    a.Membership_Amount__c = opp.Amount;
+                    a.Membership_Type__c = opp.Membership_Type__c;
                     //system.debug(opp.Allowed_Working_Groups_2__c);
                     a.Allowed_Working_Groups__c = opp.Allowed_Working_Groups_2__c;
-                    a.Primary_Membership_Contact__c = opp.Primary_Contact__c;
-                    a.Membership_Term__c = opp.Membership_Term__c;
-                    updateAcct.add(a);
                 }
+
+                updateAcct.add(a);
+               
             }
         }
         update updateAcct;

--- a/TestOpportunityTrigger.cls
+++ b/TestOpportunityTrigger.cls
@@ -44,13 +44,9 @@ private class TestOpportunityTrigger {
         opp.Account = acct;
         opp.Primary_Contact__c = c.Id;
         opp.AccountId = acct.Id;
-       
-        System.debug('Opportunity Amount ='+ opp.Amount);
-        System.debug('Record Type ='+ opp.RecordTypeId);
-        System.debug('Opp Name ='+ opp.Name);
         
         insert opp;
-        List<Opportunity> myopps =[select id from Opportunity where accountid=: acct.id];
+        //List<Opportunity> myopps =[select id from Opportunity where accountid=: acct.id];
 		//System.debug('Check number of opps on account ='+ myopps.size());
         opp.StageName = 'Invoiced';
 
@@ -58,7 +54,6 @@ private class TestOpportunityTrigger {
         Test.startTest();
         update opp;
 
-        
         // Verify by querying the temporary Salesforce database. This is the only "true" way to check if insert/updates worked.
         Account accRes = [SELECT Id, 
                           Name,
@@ -95,14 +90,8 @@ private class TestOpportunityTrigger {
         poweropp.Account = acct;
         poweropp.Primary_Contact__c = c2.Id;
         poweropp.AccountId = acct.Id;
-       
-        //System.debug('PowerSuite Opportunity Amount ='+ poweropp.Amount);
-        //System.debug('PowerSuite Record Type ='+ poweropp.RecordTypeId);
-        //System.debug('Opp Name ='+ poweropp.Name);
         
         insert poweropp;
-        
-        //List<Opportunity> myopps2 =[select id from Opportunity where accountid=: acct.id];
         
         poweropp.StageName = 'Invoiced';
 

--- a/TestOpportunityTrigger.cls
+++ b/TestOpportunityTrigger.cls
@@ -32,7 +32,7 @@ private class TestOpportunityTrigger {
         Opportunity opp = new Opportunity();
         
         opp.RecordTypeId = Schema.SObjectType.Opportunity.getRecordTypeInfosByName().get('Corporate Relations').getRecordTypeId();
-        opp.Name = acct.Name + ' AEE Member 2019';
+        opp.Name = acct.Name + ' AEE Member Test';
         opp.StageName='Awaiting Commitment';
         opp.CloseDate=System.today().addMonths(1);
         opp.Membership_type__c = 'AEE Member 2019';
@@ -85,14 +85,30 @@ private class TestOpportunityTrigger {
         poweropp.Amount = 10000;
         poweropp.Number_of_PowerSuite_Users__c = 5;
         poweropp.Type = 'Upgrade';
-        poweropp.Annual_Membership_Start_Date__c = System.today();
-        poweropp.Membership_Expiration_Date__c = System.today().addMonths(12);
+        //Intentionally making the dates in the PowerSuite Opp different then the membership opp
+        //We don't expect to copy the date values over if the customer is already a member.
+        poweropp.Annual_Membership_Start_Date__c = System.today().addMonths(2);
+        poweropp.Membership_Expiration_Date__c = System.today().addMonths(13);
         poweropp.Account = acct;
         poweropp.Primary_Contact__c = c2.Id;
         poweropp.AccountId = acct.Id;
         
         insert poweropp;
         
+        // Verify by querying database for account record that should have been changed
+        Account accResult1 = [SELECT Id, 
+                             Name,
+                             Membership_Amount__c, 
+                             Membership_Type__c, 
+                             Allowed_Working_Groups__c,
+                             Annual_Membership_Start_Date__c,
+                             Most_Recent_Expiration__c, 
+                             PowerSuite_Max_Allowed_Users__c,
+                             PowerSuite_Subscription_Amount__c,
+                             Primary_Membership_Contact__c
+                             from Account Where name = 'Test Account Eric' limit 1];
+        //System.debug('Check membership type before PowerSuite invoice ='+ accResult1.Membership_Type__c);
+        //System.debug('Check membership start date before PowerSuite invoice ='+ accResult1.Annual_Membership_Start_Date__c);
         poweropp.StageName = 'Invoiced';
 
         update poweropp;
@@ -113,26 +129,79 @@ private class TestOpportunityTrigger {
                              Primary_Membership_Contact__c
                              from Account Where name = 'Test Account Eric' limit 1];
         
-        //Check shared account fields that are used by all opps. Expecting values from PowerSuite opp 
-        //because it was the most recently modifed and is designed to overwrite an values from another opp. 
-        
-        System.assertEquals(accResult.Annual_Membership_Start_Date__c, poweropp.Annual_Membership_Start_Date__c); 
-        System.assertEquals(accResult.Most_Recent_Expiration__c, poweropp.Membership_Expiration_Date__c);
-        System.assertEquals(accResult.Primary_Membership_Contact__c, poweropp.Primary_Contact__c);
-        
         //Check membership related fields to ensure they were copied and/or not overwritten by accident.
         System.assertEquals(accResult.Membership_Amount__c, opp.Amount);
         System.assertEquals(accResult.Membership_Type__c, opp.Membership_Type__c);
         System.assertEquals(accResult.Allowed_Working_Groups__c, opp.Allowed_Working_Groups_2__c);
         
+        System.assertNotEquals(accResult.Primary_Membership_Contact__c, poweropp.Primary_Contact__c, 'PowerSuite primary contact overwrote membership contact');
+        System.assertNotEquals(accResult.Most_Recent_Expiration__c, poweropp.Membership_Expiration_Date__c);
+        
         //Check PowerSuite related fields to ensure they were copied and/or not overwritten by accident
-        System.debug('PowerSuite Subscription Amount ='+ accResult.PowerSuite_Subscription_Amount__c);
         System.assertEquals(accResult.PowerSuite_Subscription_Amount__c, poweropp.Amount);
         System.assertEquals(accResult.PowerSuite_Max_Allowed_Users__c, poweropp.Number_of_PowerSuite_Users__c);
+           
+    }
+    @isTest static void TestChangeOpportunityStagePowerSuite() {
+        // Test data setup
+        // Test coverage for when a PowerSuite opp is invoiced first i.e. the customer is pure software subscriber
+        Account acct = new Account(Name='Test Account Eric',Membership_Amount__c = 0,Email_domains__c='abc123.com');
+        insert acct;
+        System.debug('Account Name and domain='+ acct.Name + acct.Email_domains__c);
+        
+        Contact c = new Contact(FirstName='Tom',
+                                LastName='Smith', 
+                                Email='tom@abc.com',
+                                Account = acct,
+                                AccountId = acct.Id,
+                                LeadSource = 'PowerSuite Registration');
+        insert c;
+        
+        Opportunity poweropp = new Opportunity();
+        
+        poweropp.RecordTypeId = Schema.SObjectType.Opportunity.getRecordTypeInfosByName().get('Software Subscription').getRecordTypeId();
+        poweropp.Name = acct.Name + ' PowerSuite 2019';
+        poweropp.StageName='Awaiting Commitment';
+        poweropp.CloseDate=System.today().addMonths(1);
+        poweropp.Membership_type__c = 'PowerSuite Essential';
+        poweropp.Amount = 10000;
+        poweropp.Number_of_PowerSuite_Users__c = 5;
+        poweropp.Type = 'Upgrade';
+        poweropp.Annual_Membership_Start_Date__c = System.today().addMonths(2);
+        poweropp.Membership_Expiration_Date__c = System.today().addMonths(13);
+        poweropp.Account = acct;
+        poweropp.Primary_Contact__c = c.Id;
+        poweropp.AccountId = acct.Id;
+        
+        insert poweropp;
+
+        poweropp.StageName = 'Invoiced';
+		
+        Test.startTest();
+        update poweropp;       
+        Test.stopTest();
 
         
+        // Verify by querying database for account record that should have been changed
+        Account accResult = [SELECT Id, 
+                             Name,
+                             Membership_Amount__c, 
+                             Membership_Type__c, 
+                             Allowed_Working_Groups__c,
+                             Annual_Membership_Start_Date__c,
+                             Most_Recent_Expiration__c, 
+                             PowerSuite_Max_Allowed_Users__c,
+                             PowerSuite_Subscription_Amount__c,
+                             Primary_Membership_Contact__c
+                             from Account Where name = 'Test Account Eric' limit 1];
         
-        
+        //Check PowerSuite related fields to ensure they were copied and/or not overwritten by accident
+        System.assertEquals(accResult.Primary_Membership_Contact__c, poweropp.Primary_Contact__c, 'PowerSuite primary contact overwrote membership contact');
+        System.assertEquals(accResult.Annual_Membership_Start_Date__c, poweropp.Annual_Membership_Start_Date__c);
+        System.assertEquals(accResult.Most_Recent_Expiration__c, poweropp.Membership_Expiration_Date__c);
+        System.assertEquals(accResult.Membership_Type__c, 'PowerSuite Paid Subscriber');
+        System.assertEquals(accResult.PowerSuite_Subscription_Amount__c, poweropp.Amount);
+        System.assertEquals(accResult.PowerSuite_Max_Allowed_Users__c, poweropp.Number_of_PowerSuite_Users__c);
+          
     }
-    
 }

--- a/TestOpportunityTrigger.cls
+++ b/TestOpportunityTrigger.cls
@@ -1,11 +1,16 @@
+//This setting allows the test to access all actual sandbox or production data.
+//This makes for easier dev testing and has little downside.
 @isTest(SeeAllData=true)
 private class TestOpportunityTrigger {
-    @isTest static void TestDeleteAccountWithOneOpportunity() {
+    @isTest static void TestChangeOpportunityStage() {
         // Test data setup
-        // Create an account with an opportunity, and then try to delete it
+        // Create an account, two contacts and then a Membership Opportunity
+        // Invoice the membership opp
+        // Run tests to ensure that data that we are expecting is copied from the Opp to the Account
+        // Then create an PowerSuite Opp and test again to see that correct PowerSuite Opp related has been copied
         Account acct = new Account(Name='Test Account Eric',Membership_Amount__c = 0,Email_domains__c='abc123.com');
         insert acct;
-        //System.debug('Account Name ='+ acct.Name + acct.Email_domains__c);
+        System.debug('Account Name and domain='+ acct.Name + acct.Email_domains__c);
         
         Contact c = new Contact(FirstName='Tom',
                                 LastName='Smith', 
@@ -14,7 +19,15 @@ private class TestOpportunityTrigger {
                                 AccountId = acct.Id,
                                 LeadSource = 'PowerSuite Registration');
         insert c;
-        //System.debug('Contact Id ='+ c.Id);
+        
+        Contact c2 = new Contact(FirstName='Jane',
+                                LastName='Smith', 
+                                Email='jane@abc.com',
+                                Account = acct,
+                                AccountId = acct.Id,
+                                LeadSource = 'PowerSuite Registration');
+        insert c2;
+
         
         Opportunity opp = new Opportunity();
         
@@ -27,14 +40,14 @@ private class TestOpportunityTrigger {
         opp.Type = 'New';
         opp.Annual_Membership_Start_Date__c = System.today();
         opp.Membership_Expiration_Date__c = System.today().addMonths(12);
-        opp.Allowed_Working_Groups_2__c = 'Briefing Call';
+        opp.Allowed_Working_Groups_2__c = 'Policy Briefing Call';
         opp.Account = acct;
         opp.Primary_Contact__c = c.Id;
         opp.AccountId = acct.Id;
        
-        //System.debug('Opportunity Amount ='+ opp.Amount);
-        //System.debug('Record Type ='+ opp.RecordTypeId);
-        //System.debug('Opp Name ='+ opp.Name);
+        System.debug('Opportunity Amount ='+ opp.Amount);
+        System.debug('Record Type ='+ opp.RecordTypeId);
+        System.debug('Opp Name ='+ opp.Name);
         
         insert opp;
         List<Opportunity> myopps =[select id from Opportunity where accountid=: acct.id];
@@ -44,15 +57,90 @@ private class TestOpportunityTrigger {
         // Perform test
         Test.startTest();
         update opp;
+
+        
+        // Verify by querying the temporary Salesforce database. This is the only "true" way to check if insert/updates worked.
+        Account accRes = [SELECT Id, 
+                          Name,
+                          Membership_Amount__c, 
+                          Membership_Type__c, 
+                          Allowed_Working_Groups__c,
+                          Annual_Membership_Start_Date__c,
+                          Most_Recent_Expiration__c, 
+                          PowerSuite_Max_Allowed_Users__c,
+                          PowerSuite_Subscription_Amount__c,
+                          Primary_Membership_Contact__c
+                          from Account Where name = 'Test Account Eric' limit 1];
+        
+        //Testing that after the first opportunity was invoiced that values are as expected
+        System.assertEquals(accRes.Membership_Amount__c, opp.Amount);
+        System.assertEquals(accRes.Membership_Type__c, opp.Membership_Type__c);
+        System.assertEquals(accRes.Most_Recent_Expiration__c, opp.Membership_Expiration_Date__c);
+        System.assertEquals(accRes.Annual_Membership_Start_Date__c, opp.Annual_Membership_Start_Date__c);
+        System.assertEquals(accRes.Allowed_Working_Groups__c, opp.Allowed_Working_Groups_2__c);
+        
+        //Now test by creating a PowerSuite opp and invoicing
+        Opportunity poweropp = new Opportunity();
+        
+        poweropp.RecordTypeId = Schema.SObjectType.Opportunity.getRecordTypeInfosByName().get('Software Subscription').getRecordTypeId();
+        poweropp.Name = acct.Name + ' PowerSuite 2019';
+        poweropp.StageName='Awaiting Commitment';
+        poweropp.CloseDate=System.today().addMonths(1);
+        poweropp.Membership_type__c = 'PowerSuite Essential';
+        poweropp.Amount = 10000;
+        poweropp.Number_of_PowerSuite_Users__c = 5;
+        poweropp.Type = 'Upgrade';
+        poweropp.Annual_Membership_Start_Date__c = System.today();
+        poweropp.Membership_Expiration_Date__c = System.today().addMonths(12);
+        poweropp.Account = acct;
+        poweropp.Primary_Contact__c = c2.Id;
+        poweropp.AccountId = acct.Id;
+       
+        //System.debug('PowerSuite Opportunity Amount ='+ poweropp.Amount);
+        //System.debug('PowerSuite Record Type ='+ poweropp.RecordTypeId);
+        //System.debug('Opp Name ='+ poweropp.Name);
+        
+        insert poweropp;
+        
+        //List<Opportunity> myopps2 =[select id from Opportunity where accountid=: acct.id];
+        
+        poweropp.StageName = 'Invoiced';
+
+        update poweropp;
+        
         Test.stopTest();
 
         
-        // Verify by querying database
-        Account accRes = [SELECT Id, Name,Membership_Amount__c, Membership_Type__c,Allowed_Working_Groups__c from Account Where name = 'Test Account Eric' limit 1];
-        System.debug('Account Amount ='+ accRes.Membership_Amount__c);
-        System.assertEquals(accRes.Membership_Amount__c, opp.Amount);
-        System.assertEquals(accRes.Membership_Type__c, opp.Membership_Type__c);
-        System.assertEquals(accRes.Allowed_Working_Groups__c, opp.Allowed_Working_Groups_2__c);
+        // Verify by querying database for account record that should have been changed
+        Account accResult = [SELECT Id, 
+                             Name,
+                             Membership_Amount__c, 
+                             Membership_Type__c, 
+                             Allowed_Working_Groups__c,
+                             Annual_Membership_Start_Date__c,
+                             Most_Recent_Expiration__c, 
+                             PowerSuite_Max_Allowed_Users__c,
+                             PowerSuite_Subscription_Amount__c,
+                             Primary_Membership_Contact__c
+                             from Account Where name = 'Test Account Eric' limit 1];
+        
+        //Check shared account fields that are used by all opps. Expecting values from PowerSuite opp 
+        //because it was the most recently modifed and is designed to overwrite an values from another opp. 
+        
+        System.assertEquals(accResult.Annual_Membership_Start_Date__c, poweropp.Annual_Membership_Start_Date__c); 
+        System.assertEquals(accResult.Most_Recent_Expiration__c, poweropp.Membership_Expiration_Date__c);
+        System.assertEquals(accResult.Primary_Membership_Contact__c, poweropp.Primary_Contact__c);
+        
+        //Check membership related fields to ensure they were copied and/or not overwritten by accident.
+        System.assertEquals(accResult.Membership_Amount__c, opp.Amount);
+        System.assertEquals(accResult.Membership_Type__c, opp.Membership_Type__c);
+        System.assertEquals(accResult.Allowed_Working_Groups__c, opp.Allowed_Working_Groups_2__c);
+        
+        //Check PowerSuite related fields to ensure they were copied and/or not overwritten by accident
+        System.debug('PowerSuite Subscription Amount ='+ accResult.PowerSuite_Subscription_Amount__c);
+        System.assertEquals(accResult.PowerSuite_Subscription_Amount__c, poweropp.Amount);
+        System.assertEquals(accResult.PowerSuite_Max_Allowed_Users__c, poweropp.Number_of_PowerSuite_Users__c);
+
         
         
         


### PR DESCRIPTION
- New code accounts for two open opps at invoiced stage (or more) which is common when members purchase PowerSuite and membership seperately
- Cleans up out of date logic
- Extra comments